### PR TITLE
Columned checklist, Detail rendering button, and failed HeroOptions

### DIFF
--- a/src/components/FullBody.js
+++ b/src/components/FullBody.js
@@ -1,10 +1,40 @@
-// the component that shows up when someone selects "Full Body"
+// the Detail that shows up when someone selects "Full Body"
 
 import ExercisesChecklist from "../features/exercises/ExercisesChecklist";
+import {Col, Row, Card} from 'reactstrap';
+import React, { useState } from "react";
+
+// This component is a placeholder for ExerciseDetail
+function TestDetail() {
+    return (
+      <div className='m-4'>
+        
+            <h4>This is where ExerciseDetail Will Render</h4>
+            <p>The button needs to be next to each checklist item</p>
+      </div>
+    );
+  }
+// End of Test component
 
 const FullBody = () => {
+    const [showDetail, setShowDetail] = useState(false);
+    const toggleDetail = () => {
+        setShowDetail(!showDetail);
+    }
+
+
     return (
-        <ExercisesChecklist />
+        <Row className='ms-auto'>
+            <ExercisesChecklist />
+            
+            <Col className='col-sm-6'>
+                {showDetail && <TestDetail />}
+                <button onClick={toggleDetail} >
+                        {showDetail ? 'Turn Off ExerciseDetail' : 'Turn On ExerciseDetail'}
+                      </button>
+            </Col>
+
+        </Row>
     );
 };
 

--- a/src/components/Hero/HeroOptionsNavigate.js
+++ b/src/components/Hero/HeroOptionsNavigate.js
@@ -1,0 +1,52 @@
+import { Routes, Route } from "react-router-dom";
+import FullBody from "../FullBody";
+import LowerBody from "../LowerBody";
+import UpperBody from "../UpperBody";
+import { Formik, Field, Form } from 'formik';
+import { Link } from 'react-router-dom';
+import { useNavigate } from "react-router-dom";
+
+const HeroOptions = () => {
+  const navigate = useNavigate();
+  
+    return (
+    <div>
+    <h1>HeroOptions</h1>
+    <Formik
+      initialValues={{
+        picked: '',
+      }}
+      onSubmit={(values) => {
+          const path = `/${values.exerciseOption}`; // Dynamic path based on selection
+          navigate(path);
+        }}
+    >
+      {({ values }) => (
+        <Form>
+          <div id="exercise-group">Choose your workout:</div>
+          <div role="group" aria-labelledby="exercise-group">
+            <label>
+              <Field type="radio" name="exerciseOption" value="fullBody" />
+              Full Body
+            </label>
+            <label>
+              <Field type="radio" name="exerciseOption" value="UpperBody" />
+              Upper Body
+            </label>
+            <label>
+              <Field type="radio" name="exerciseOption" value="LowerBody" />
+              Lower Body
+            </label>
+            <div>Picked: {values.exerciseOption}</div>
+          </div>
+
+          <button type="submit">Submit</button>
+        </Form>
+      )}
+    </Formik>
+      
+  </div>
+    );
+};
+
+export default HeroOptions;

--- a/src/features/exercises/ExercisesChecklist.js
+++ b/src/features/exercises/ExercisesChecklist.js
@@ -1,6 +1,6 @@
 // This is where users see their subset of options and their selected exercises / difficulty
 
-import {Col, Row} from 'reactstrap';
+import {Col, Row, Card} from 'reactstrap';
 import ExercisesCheckbox from './ExercisesCheckbox';
 import { selectFullBody } from './exercisesSlice';
 import { useSelector } from 'react-redux';
@@ -10,22 +10,23 @@ const ExercisesChecklist = () => {
     console.log('exercises:', exercises);
     
     return (
-        <Row className='ms-auto'>
-            {
-                exercises.map((exercise) => {
-                    return (
-                        <Col
-                            md='5'
-                            className='m-4'
-                            key={exercise.id}
-                        >
-                            <ExercisesCheckbox exercise={exercise}/>
-                        </Col>
-                    );
-                }) 
-            }
+            
+            <Col className='col-sm-6'>
+                {
+                    exercises.map((exercise) => {
+                        return (
+                            <Card
+                                
+                                className='m-4'
+                                key={exercise.id}
+                            >
+                                <ExercisesCheckbox exercise={exercise}/>
+                            </Card>
+                        );
+                    })
+                }
+            </Col>
 
-        </Row>
     );
 }
 


### PR DESCRIPTION
1) The new HeroOptionsNavigate.js is my failed attempt at making HeroOptions navigate correctly. It *technically* worked, but it broke the ExerciseDetail render in the process, so I'm keeping it to play with later. 

2) I rearranged which components were wrapped in a Col so Checklist and Detail could appear side by side on larger screen sizes instead of routing away from the checklist. At the moment there's a placeholder component to make sure I was using state correctly, but I haven't attempted to connect the actual Detail component to it yet. 

3) Here's my proposal for handling the checkbox components: We wrap them in a card (like you did, miranda) and have the checkbox side by side with a Show Details button. This way the user can look at the details before adding them to their routine (I'm hoping this will also make it simpler to add checklist items to the final workout routine).